### PR TITLE
fix melos publish

### DIFF
--- a/.github/workflows/pub-lish.yml
+++ b/.github/workflows/pub-lish.yml
@@ -44,4 +44,4 @@ jobs:
           melos bootstrap
       - name: 'publishing'
         run: |
-          melos run publish
+          yes | melos run publish

--- a/packages/byte_token/example
+++ b/packages/byte_token/example
@@ -1,1 +1,0 @@
-../../examples/byte_token

--- a/packages/byte_token/example/README.md
+++ b/packages/byte_token/example/README.md
@@ -1,0 +1,2 @@
+
+https://github.com/iapicca/yak_packages/tree/master/examples/byte_token

--- a/packages/stub/example
+++ b/packages/stub/example
@@ -1,1 +1,0 @@
-../../examples/stub

--- a/packages/stub/example/README.md
+++ b/packages/stub/example/README.md
@@ -1,0 +1,2 @@
+
+https://github.com/iapicca/yak_packages/tree/master/examples/stub

--- a/packages/yak_flutter/example
+++ b/packages/yak_flutter/example
@@ -1,1 +1,0 @@
-../../examples/yak_flutter

--- a/packages/yak_flutter/example/README.md
+++ b/packages/yak_flutter/example/README.md
@@ -1,0 +1,2 @@
+
+https://github.com/iapicca/yak_packages/tree/master/examples/yak_flutter

--- a/packages/yak_result/example
+++ b/packages/yak_result/example
@@ -1,1 +1,0 @@
-../../examples/yak_result

--- a/packages/yak_result/example/README.md
+++ b/packages/yak_result/example/README.md
@@ -1,0 +1,2 @@
+
+https://github.com/iapicca/yak_packages/tree/master/examples/yak_result

--- a/packages/yak_runner/example
+++ b/packages/yak_runner/example
@@ -1,1 +1,0 @@
-../../examples/yak_runner

--- a/packages/yak_runner/example/README.md
+++ b/packages/yak_runner/example/README.md
@@ -1,0 +1,2 @@
+
+https://github.com/iapicca/yak_packages/tree/master/examples/yak_runner

--- a/packages/yak_tween/example
+++ b/packages/yak_tween/example
@@ -1,1 +1,0 @@
-../../examples/yak_tween

--- a/packages/yak_tween/example/README.md
+++ b/packages/yak_tween/example/README.md
@@ -1,0 +1,2 @@
+
+https://github.com/iapicca/yak_packages/tree/master/examples/yak_tween


### PR DESCRIPTION
- add publish_to: none in examples pubspec
- replace example symlink with markdown file
- update publishing script in workflows

fix https://github.com/iapicca/yak_packages/issues/180
